### PR TITLE
Add storefront view with search and filters

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -49,6 +49,6 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 | Examples:	my-controller/index	-> my_controller/index
 |		my-controller/my-method	-> my_controller/my_method
 */
-$route['default_controller'] = 'welcome';
+$route['default_controller'] = 'store';
 $route['404_override'] = '';
 $route['translate_uri_dashes'] = FALSE;

--- a/application/controllers/Store.php
+++ b/application/controllers/Store.php
@@ -1,0 +1,40 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Store extends CI_Controller {
+    public function index()
+    {
+        $items = [
+            ['name' => 'Camisa Floral', 'category' => 'Roupas', 'price' => 19.99, 'image' => 'https://via.placeholder.com/150'],
+            ['name' => 'Calças Jeans', 'category' => 'Roupas', 'price' => 29.99, 'image' => 'https://via.placeholder.com/150'],
+            ['name' => 'Tênis Esportivos', 'category' => 'Calçados', 'price' => 49.99, 'image' => 'https://via.placeholder.com/150'],
+            ['name' => 'Relógio Clássico', 'category' => 'Acessórios', 'price' => 99.99, 'image' => 'https://via.placeholder.com/150'],
+        ];
+
+        $query = $this->input->get('q');
+        $category = $this->input->get('category');
+
+        $filtered = array_filter($items, function ($item) use ($query, $category) {
+            $match = true;
+            if ($query) {
+                $match = stripos($item['name'], $query) !== false;
+            }
+            if ($match && $category && $category !== 'all') {
+                $match = $item['category'] === $category;
+            }
+            return $match;
+        });
+
+        $data['items'] = $filtered;
+        $data['query'] = $query;
+        $data['category'] = $category;
+        $data['categories'] = [
+            'all' => 'Todas',
+            'Roupas' => 'Roupas',
+            'Calçados' => 'Calçados',
+            'Acessórios' => 'Acessórios'
+        ];
+
+        $this->load->view('storefront', $data);
+    }
+}

--- a/application/views/storefront.php
+++ b/application/views/storefront.php
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="utf-8">
+    <title>Vitrine da Loja</title>
+    <link rel="stylesheet" href="/assets/css/store.css">
+</head>
+<body>
+    <h1>Vitrine da Loja</h1>
+    <form method="get" class="filters">
+        <input type="text" name="q" placeholder="Pesquisar produtos" value="<?php echo htmlspecialchars($query); ?>">
+        <select name="category">
+            <?php foreach ($categories as $key => $label): ?>
+                <option value="<?php echo $key; ?>" <?php echo ($category === $key || (!$category && $key==='all')) ? 'selected' : ''; ?>>
+                    <?php echo $label; ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+        <button type="submit">Buscar</button>
+    </form>
+
+    <div class="products">
+        <?php foreach ($items as $item): ?>
+            <div class="product-card">
+                <img src="<?php echo $item['image']; ?>" alt="<?php echo htmlspecialchars($item['name']); ?>">
+                <h3><?php echo $item['name']; ?></h3>
+                <p class="category"><?php echo $item['category']; ?></p>
+                <p class="price">€<?php echo number_format($item['price'], 2, ',', '.'); ?></p>
+            </div>
+        <?php endforeach; ?>
+        <?php if (empty($items)): ?>
+            <p>Nenhum produto encontrado.</p>
+        <?php endif; ?>
+    </div>
+</body>
+</html>

--- a/assets/css/store.css
+++ b/assets/css/store.css
@@ -1,0 +1,26 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+.filters {
+    margin-bottom: 20px;
+}
+.products {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 20px;
+}
+.product-card {
+    border: 1px solid #ddd;
+    padding: 10px;
+    text-align: center;
+    background: #fff;
+}
+.product-card img {
+    max-width: 100%;
+    height: auto;
+}
+.price {
+    font-weight: bold;
+    color: #d33;
+}


### PR DESCRIPTION
## Summary
- Add Store controller and storefront view for visitors with search and category filtering
- Provide basic grid styling via assets/css/store.css
- Route default controller to Store so visitors land on storefront

## Testing
- `php -l application/controllers/Store.php`
- `php -l application/views/storefront.php`
- `composer test:coverage` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b18fd1df2c8322b3439050e1ba29d3