### PR TITLE
Adiciona pesquisa e filtros à listagem de produtos

### DIFF
--- a/application/controllers/Products.php
+++ b/application/controllers/Products.php
@@ -8,7 +8,15 @@ class Products extends CI_Controller {
     }
 
     public function index() {
-        $data['products'] = $this->Product_model->get_all();
+        $q = $this->input->get('q');
+        $min_price = $this->input->get('min_price');
+        $max_price = $this->input->get('max_price');
+
+        $data['products'] = $this->Product_model->search($q, $min_price, $max_price);
+        $data['q'] = $q;
+        $data['min_price'] = $min_price;
+        $data['max_price'] = $max_price;
+
         $this->load->view('products/list', $data);
     }
 }

--- a/application/models/Product_model.php
+++ b/application/models/Product_model.php
@@ -11,4 +11,30 @@ class Product_model extends CI_Model {
     public function get_all() {
         return $this->products;
     }
+
+    /**
+     * Busca produtos pelo nome e filtra por faixa de preço.
+     *
+     * @param string $term Termo de pesquisa.
+     * @param float|null $min_price Preço mínimo.
+     * @param float|null $max_price Preço máximo.
+     * @return array Lista de produtos filtrados.
+     */
+    public function search($term = '', $min_price = null, $max_price = null) {
+        $term = strtolower($term);
+
+        return array_values(array_filter($this->products, function ($p) use ($term, $min_price, $max_price) {
+            if ($term && strpos(strtolower($p['name']), $term) === false) {
+                return false;
+            }
+            if ($min_price !== null && $p['price'] < (float) $min_price) {
+                return false;
+            }
+            if ($max_price !== null && $p['price'] > (float) $max_price) {
+                return false;
+            }
+
+            return true;
+        }));
+    }
 }

--- a/application/views/products/list.php
+++ b/application/views/products/list.php
@@ -7,6 +7,26 @@
 </head>
 <body class="container py-4">
   <h1 class="mb-4">Catálogo</h1>
+  <form method="get" class="mb-4">
+    <div class="row g-2">
+      <div class="col-md-4">
+        <input type="text" name="q" class="form-control" placeholder="Pesquisar" value="<?= html_escape($q) ?>">
+      </div>
+      <div class="col-md-2">
+        <input type="number" step="0.01" name="min_price" class="form-control" placeholder="Preço min" value="<?= html_escape($min_price) ?>">
+      </div>
+      <div class="col-md-2">
+        <input type="number" step="0.01" name="max_price" class="form-control" placeholder="Preço max" value="<?= html_escape($max_price) ?>">
+      </div>
+      <div class="col-md-2">
+        <button type="submit" class="btn btn-primary w-100">Filtrar</button>
+      </div>
+      <div class="col-md-2">
+        <a href="<?= site_url('products') ?>" class="btn btn-secondary w-100">Limpar</a>
+      </div>
+    </div>
+  </form>
+
   <table class="table table-striped">
     <thead>
       <tr>
@@ -14,6 +34,11 @@
       </tr>
     </thead>
     <tbody>
+      <?php if (empty($products)): ?>
+      <tr>
+        <td colspan="4" class="text-center">Nenhum produto encontrado.</td>
+      </tr>
+      <?php endif; ?>
       <?php foreach ($products as $p): ?>
       <tr>
         <td><?= $p['id'] ?></td>


### PR DESCRIPTION
## Summary
- adiciona método `search` ao Product_model para filtrar por nome e faixa de preço
- atualiza controlador Products para aceitar parâmetros de busca e filtro
- adiciona formulário de pesquisa e mensagem de ausência de resultados na view

## Testing
- `php -l application/models/Product_model.php`
- `php -l application/controllers/Products.php`
- `php -l application/views/products/list.php`


------
https://chatgpt.com/codex/tasks/task_e_68b193e5ecb88322bef5a2cf9a99195e