### PR TITLE
Add shop pages for home, sale, and product details

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -52,3 +52,6 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 $route['default_controller'] = 'products';
 $route['404_override'] = '';
 $route['translate_uri_dashes'] = FALSE;
+$route['shop'] = 'shop/home';
+$route['shop/sale'] = 'shop/sale';
+$route['shop/product/(:num)'] = 'shop/product/$1';

--- a/application/controllers/Shop.php
+++ b/application/controllers/Shop.php
@@ -1,0 +1,28 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Shop extends CI_Controller {
+    public function __construct() {
+        parent::__construct();
+        $this->load->model('Product_model');
+    }
+
+    public function home() {
+        $data['products'] = $this->Product_model->get_all();
+        $this->load->view('shop/home', $data);
+    }
+
+    public function sale() {
+        $data['products'] = $this->Product_model->get_on_sale();
+        $this->load->view('shop/sale', $data);
+    }
+
+    public function product($id) {
+        $product = $this->Product_model->get($id);
+        if (!$product) {
+            show_404();
+            return;
+        }
+        $this->load->view('shop/product', ['product' => $product]);
+    }
+}

--- a/application/models/Product_model.php
+++ b/application/models/Product_model.php
@@ -3,13 +3,65 @@ defined('BASEPATH') OR exit('No direct script access allowed');
 
 class Product_model extends CI_Model {
     private $products = [
-        ['id' => 1, 'name' => 'Vestido Floral', 'price' => 120.0, 'stock' => 10],
-        ['id' => 2, 'name' => 'Saia Jeans', 'price' => 80.0, 'stock' => 5],
-        ['id' => 3, 'name' => 'Blusa de Seda', 'price' => 95.0, 'stock' => 8],
+        [
+            'id' => 1,
+            'name' => 'Shopping Bag',
+            'price' => 59.99,
+            'stock' => 15,
+            'description' => 'Durable bag for everyday use.',
+            'image' => 'https://via.placeholder.com/300?text=Bag',
+            'category' => 'accessories',
+            'on_sale' => true,
+        ],
+        [
+            'id' => 2,
+            'name' => 'Warming T-shirt',
+            'price' => 39.99,
+            'stock' => 20,
+            'description' => 'Soft cotton t-shirt to keep you warm.',
+            'image' => 'https://via.placeholder.com/300?text=T-shirt',
+            'category' => 'clothes',
+            'on_sale' => true,
+        ],
+        [
+            'id' => 3,
+            'name' => 'Basic Shirt',
+            'price' => 70.00,
+            'stock' => 25,
+            'description' => 'Classic shirt for all occasions.',
+            'image' => 'https://via.placeholder.com/300?text=Shirt',
+            'category' => 'clothes',
+            'on_sale' => false,
+        ],
+        [
+            'id' => 4,
+            'name' => 'Sweater Unisex',
+            'price' => 32.45,
+            'stock' => 20,
+            'description' => 'Cozy green sweater for everyone.',
+            'image' => 'https://via.placeholder.com/300?text=Sweater',
+            'category' => 'clothes',
+            'on_sale' => false,
+        ],
     ];
 
     public function get_all() {
         return $this->products;
+    }
+
+    public function get($id) {
+        foreach ($this->products as $p) {
+            if ($p['id'] == $id) {
+                return $p;
+            }
+        }
+        return null;
+    }
+
+    public function get_on_sale() {
+        return array_values(array_filter($this->products, function ($p) {
+            return !empty($p['on_sale']);
+        }));
     }
 
     /**

--- a/application/views/shop/home.php
+++ b/application/views/shop/home.php
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="utf-8">
+  <title>Shipshop - Home</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+  <h1 class="mb-3">Shipshop</h1>
+  <div class="mb-4">
+    <img src="https://via.placeholder.com/800x300?text=New+Season" class="img-fluid rounded" alt="New season">
+  </div>
+
+  <h2 class="h5 mb-3">Categories</h2>
+  <div class="row g-3 text-center">
+    <div class="col-4">
+      <div class="card h-100">
+        <img src="https://via.placeholder.com/150?text=Women" class="card-img-top" alt="Women">
+        <div class="card-body p-2"><p class="card-text">Women</p></div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="card h-100">
+        <img src="https://via.placeholder.com/150?text=Men" class="card-img-top" alt="Men">
+        <div class="card-body p-2"><p class="card-text">Men</p></div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="card h-100">
+        <img src="https://via.placeholder.com/150?text=Kids" class="card-img-top" alt="Kids">
+        <div class="card-body p-2"><p class="card-text">Kids</p></div>
+      </div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/application/views/shop/product.php
+++ b/application/views/shop/product.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="utf-8">
+  <title><?= $product['name'] ?></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+  <a href="<?= site_url('shop/sale') ?>" class="btn btn-link mb-3">&larr; Voltar</a>
+  <div class="text-center mb-3">
+    <img src="<?= $product['image'] ?>" class="img-fluid" alt="<?= $product['name'] ?>">
+  </div>
+  <h2 class="mb-3"><?= $product['name'] ?></h2>
+  <p class="text-muted">$<?= number_format($product['price'], 2) ?></p>
+  <p><?= $product['description'] ?></p>
+  <p class="text-muted">In stock: <?= $product['stock'] ?></p>
+  <button class="btn btn-dark">Add to bag</button>
+</div>
+</body>
+</html>

--- a/application/views/shop/sale.php
+++ b/application/views/shop/sale.php
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="utf-8">
+  <title>Shipshop - On Sale</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+  <h1 class="mb-4">On Sale</h1>
+  <div class="row g-3">
+    <?php foreach ($products as $p): ?>
+    <div class="col-6">
+      <div class="card h-100">
+        <img src="<?= $p['image'] ?>" class="card-img-top" alt="<?= $p['name'] ?>">
+        <div class="card-body">
+          <h5 class="card-title"><?= $p['name'] ?></h5>
+          <p class="card-text">$<?= number_format($p['price'], 2) ?></p>
+          <a href="<?= site_url('shop/product/'.$p['id']) ?>" class="btn btn-sm btn-primary">View</a>
+        </div>
+      </div>
+    </div>
+    <?php endforeach; ?>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expand `Product_model` with sample data including descriptions, images and sale flags
- add `Shop` controller with routes for home, sale and product detail pages
- create basic Bootstrap views for home categories, sale list and product detail screens

## Testing
- `php -l application/models/Product_model.php`
- `php -l application/controllers/Shop.php`
- `php -l application/views/shop/home.php`
- `php -l application/views/shop/sale.php`
- `php -l application/views/shop/product.php`
- `php -l application/config/routes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1a3da6964832288a94ebb0d719c05